### PR TITLE
feat: persist restaurant id after device association

### DIFF
--- a/app/src/main/java/digital/studioweb/selfhub_app/data/di/AppModule.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/data/di/AppModule.kt
@@ -25,6 +25,7 @@ import digital.studioweb.selfhub_app.domain.features.auth.AuthRepository
 import digital.studioweb.selfhub_app.domain.features.auth.GetCNPJUseCase
 import digital.studioweb.selfhub_app.domain.features.auth.GetRestaurantByCNPJUseCase
 import digital.studioweb.selfhub_app.domain.features.auth.SaveCNPJUseCase
+import digital.studioweb.selfhub_app.domain.features.auth.SaveRestaurantIdUseCase
 import digital.studioweb.selfhub_app.domain.features.cart.CartCreateOrderUseCase
 import digital.studioweb.selfhub_app.domain.features.cart.CartRepository
 import digital.studioweb.selfhub_app.domain.features.home.HomeGetCategoriesUseCase
@@ -121,6 +122,12 @@ object AppModule {
     @Singleton
     fun provideSaveCNPJUseCase(authRepository: AuthRepository): SaveCNPJUseCase {
         return SaveCNPJUseCase(authRepository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSaveRestaurantIdUseCase(authRepository: AuthRepository): SaveRestaurantIdUseCase {
+        return SaveRestaurantIdUseCase(authRepository)
     }
 
     @Provides

--- a/app/src/main/java/digital/studioweb/selfhub_app/data/features/auth/AuthAPI.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/data/features/auth/AuthAPI.kt
@@ -2,6 +2,7 @@ package digital.studioweb.selfhub_app.data.features.auth
 
 import digital.studioweb.selfhub_app.data.base.ApiResponse
 import digital.studioweb.selfhub_app.data.features.auth.models.AssociateDeviceRequestDTO
+import digital.studioweb.selfhub_app.data.features.auth.models.RestaurantDTO
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -12,7 +13,7 @@ interface AuthAPI {
     @POST("auth/associate-device")
     suspend fun associateDevice(
         @Body associateDeviceRequest: AssociateDeviceRequestDTO
-    ): ApiResponse<Unit>
+    ): ApiResponse<RestaurantDTO>
 
     @GET("restaurant/{restaurantCnpj}")
     suspend fun getRestaurantByCNPJ(

--- a/app/src/main/java/digital/studioweb/selfhub_app/data/features/auth/AuthAPIDataSource.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/data/features/auth/AuthAPIDataSource.kt
@@ -2,11 +2,12 @@ package digital.studioweb.selfhub_app.data.features.auth
 
 import digital.studioweb.selfhub_app.data.base.ApiResponse
 import digital.studioweb.selfhub_app.data.features.auth.models.AssociateDeviceRequestDTO
+import digital.studioweb.selfhub_app.data.features.auth.models.RestaurantDTO
 
 interface AuthAPIDataSource{
     suspend fun associateDevice(
         associateDeviceRequest: AssociateDeviceRequestDTO
-    ): ApiResponse<Unit>
+    ): ApiResponse<RestaurantDTO>
 
     suspend fun getRestaurantByCNPJ(cnpj: String): ApiResponse<Unit>
 }
@@ -17,7 +18,7 @@ class AuthAPIDataSourceImpl(
 
     override suspend fun associateDevice(
         associateDeviceRequest: AssociateDeviceRequestDTO
-    ): ApiResponse<Unit> {
+    ): ApiResponse<RestaurantDTO> {
         return authAPI.associateDevice(associateDeviceRequest)
     }
 

--- a/app/src/main/java/digital/studioweb/selfhub_app/data/features/auth/AuthLocalDataSource.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/data/features/auth/AuthLocalDataSource.kt
@@ -2,10 +2,13 @@ package digital.studioweb.selfhub_app.data.features.auth
 
 import digital.studioweb.selfhub_app.data.sources.SecureSharedLocalDataSourceInterface
 import digital.studioweb.selfhub_app.data.utils.LocalConstants.CNPJ_KEY
+import digital.studioweb.selfhub_app.data.utils.LocalConstants.RESTAURANT_ID_KEY
 
 interface AuthLocalDataSource {
     fun getCNPJ(): String
     fun saveCNPJ(cnpj: String)
+    fun getRestaurantId(): String
+    fun saveRestaurantId(restaurantId: String)
 }
 
 class AuthLocalDataSourceImpl(
@@ -22,6 +25,20 @@ class AuthLocalDataSourceImpl(
         secureSharedLocalDataSource.store(
             key = CNPJ_KEY,
             value = cnpj
+        )
+    }
+
+    override fun getRestaurantId(): String {
+        return secureSharedLocalDataSource.retrieve(
+            key = RESTAURANT_ID_KEY,
+            clazz = String::class
+        ) ?: ""
+    }
+
+    override fun saveRestaurantId(restaurantId: String) {
+        secureSharedLocalDataSource.store(
+            key = RESTAURANT_ID_KEY,
+            value = restaurantId
         )
     }
 }

--- a/app/src/main/java/digital/studioweb/selfhub_app/data/features/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/data/features/auth/AuthRepositoryImpl.kt
@@ -2,6 +2,7 @@ package digital.studioweb.selfhub_app.data.features.auth
 
 import digital.studioweb.selfhub_app.domain.features.auth.AuthRepository
 import digital.studioweb.selfhub_app.domain.features.auth.models.AssociateDeviceRequestModel
+import digital.studioweb.selfhub_app.domain.features.auth.models.AssociateDeviceResponseModel
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
@@ -12,10 +13,15 @@ class AuthRepositoryImpl @Inject constructor(
         TODO("Not yet implemented")
     }
 
-    override suspend fun associateDevice(associateDeviceRequest: AssociateDeviceRequestModel) {
-        return authAPIDataSource.associateDevice(
+    override suspend fun associateDevice(associateDeviceRequest: AssociateDeviceRequestModel): AssociateDeviceResponseModel {
+        val response = authAPIDataSource.associateDevice(
             associateDeviceRequest.mapToDTO()
-        ).response
+        )
+        return AssociateDeviceResponseModel(
+            statusCode = response.statusCode,
+            message = response.message,
+            restaurant = response.response.mapTo()
+        )
     }
 
     override fun getCNPJ(): String {
@@ -24,6 +30,14 @@ class AuthRepositoryImpl @Inject constructor(
 
     override fun saveCNPJ(cnpj: String) {
         return authLocalDataSource.saveCNPJ(cnpj = cnpj)
+    }
+
+    override fun getRestaurantId(): String {
+        return authLocalDataSource.getRestaurantId()
+    }
+
+    override fun saveRestaurantId(restaurantId: String) {
+        authLocalDataSource.saveRestaurantId(restaurantId)
     }
 
     override suspend fun getRestaurantByCNPJ(cnpj: String) {

--- a/app/src/main/java/digital/studioweb/selfhub_app/data/features/auth/models/RestaurantDTO.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/data/features/auth/models/RestaurantDTO.kt
@@ -1,0 +1,29 @@
+package digital.studioweb.selfhub_app.data.features.auth.models
+
+import digital.studioweb.selfhub_app.domain.features.auth.models.RestaurantModel
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RestaurantDTO(
+    @SerialName("id")
+    val id: String,
+
+    @SerialName("name")
+    val name: String,
+
+    @SerialName("cnpj")
+    val cnpj: String,
+
+    @SerialName("created_at")
+    val createdAt: String,
+) {
+    fun mapTo(): RestaurantModel {
+        return RestaurantModel(
+            id = id,
+            name = name,
+            cnpj = cnpj,
+            createdAt = createdAt,
+        )
+    }
+}

--- a/app/src/main/java/digital/studioweb/selfhub_app/data/features/home/HomeRepositoryImpl.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/data/features/home/HomeRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package digital.studioweb.selfhub_app.data.features.home
 
 import digital.studioweb.selfhub_app.data.sources.SecureSharedLocalDataSourceInterface
-import digital.studioweb.selfhub_app.data.utils.LocalConstants.CNPJ_KEY
+import digital.studioweb.selfhub_app.data.utils.LocalConstants.RESTAURANT_ID_KEY
 import digital.studioweb.selfhub_app.domain.features.home.HomeRepository
 import digital.studioweb.selfhub_app.domain.features.home.models.CategoryModel
 import digital.studioweb.selfhub_app.domain.features.home.models.ProductModel
@@ -13,13 +13,13 @@ class HomeRepositoryImpl @Inject constructor(
 ) : HomeRepository {
     override suspend fun getCategories(): List<CategoryModel> {
         return homeAPI.getCategories(
-            restaurantId = secureSharedLocalDataSource.retrieve(CNPJ_KEY, String::class) ?: ""
+            restaurantId = secureSharedLocalDataSource.retrieve(RESTAURANT_ID_KEY, String::class) ?: ""
         ).response.map { it.mapTo() }
     }
 
     override suspend fun getAllProducts(): List<ProductModel> {
         return homeAPI.getProducts(
-            restaurantId = secureSharedLocalDataSource.retrieve(CNPJ_KEY, String::class) ?: ""
+            restaurantId = secureSharedLocalDataSource.retrieve(RESTAURANT_ID_KEY, String::class) ?: ""
         ).response.map { it.mapTo() }
     }
 }

--- a/app/src/main/java/digital/studioweb/selfhub_app/data/utils/LocalConstants.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/data/utils/LocalConstants.kt
@@ -12,5 +12,6 @@ object LocalConstants {
      * Shared Preferences Keys
      */
     const val CNPJ_KEY = "CNPJKey"
+    const val RESTAURANT_ID_KEY = "RestaurantIdKey"
 
 }

--- a/app/src/main/java/digital/studioweb/selfhub_app/domain/features/auth/AssociateDeviceUseCase.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/domain/features/auth/AssociateDeviceUseCase.kt
@@ -2,13 +2,14 @@ package digital.studioweb.selfhub_app.domain.features.auth
 
 import digital.studioweb.selfhub_app.domain.base.BaseAsyncUseCase
 import digital.studioweb.selfhub_app.domain.features.auth.models.AssociateDeviceRequestModel
+import digital.studioweb.selfhub_app.domain.features.auth.models.AssociateDeviceResponseModel
 
 class AssociateDeviceUseCase(
     private val repository: AuthRepository
-) : BaseAsyncUseCase<Result<Unit>, AssociateDeviceUseCase.Params>() {
+) : BaseAsyncUseCase<Result<AssociateDeviceResponseModel>, AssociateDeviceUseCase.Params>() {
     data class Params(val cnpj: String, val macAddress: String)
 
-    override suspend fun runAsync(params: Params): Result<Unit> {
+    override suspend fun runAsync(params: Params): Result<AssociateDeviceResponseModel> {
         try {
             val request = AssociateDeviceRequestModel(
                 macAddress = params.macAddress,

--- a/app/src/main/java/digital/studioweb/selfhub_app/domain/features/auth/AuthRepository.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/domain/features/auth/AuthRepository.kt
@@ -1,11 +1,14 @@
 package digital.studioweb.selfhub_app.domain.features.auth
 
 import digital.studioweb.selfhub_app.domain.features.auth.models.AssociateDeviceRequestModel
+import digital.studioweb.selfhub_app.domain.features.auth.models.AssociateDeviceResponseModel
 
 interface AuthRepository {
     suspend fun getAssociation(): String
-    suspend fun associateDevice(associateDeviceRequest: AssociateDeviceRequestModel)
+    suspend fun associateDevice(associateDeviceRequest: AssociateDeviceRequestModel): AssociateDeviceResponseModel
     fun getCNPJ(): String
     fun saveCNPJ(cnpj: String)
+    fun getRestaurantId(): String
+    fun saveRestaurantId(restaurantId: String)
     suspend fun getRestaurantByCNPJ(cnpj: String)
 }

--- a/app/src/main/java/digital/studioweb/selfhub_app/domain/features/auth/SaveRestaurantIdUseCase.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/domain/features/auth/SaveRestaurantIdUseCase.kt
@@ -1,0 +1,13 @@
+package digital.studioweb.selfhub_app.domain.features.auth
+
+import digital.studioweb.selfhub_app.domain.base.BaseUseCase
+
+class SaveRestaurantIdUseCase(
+    private val repository: AuthRepository
+) : BaseUseCase<Unit, SaveRestaurantIdUseCase.Params>() {
+    data class Params(val restaurantId: String)
+
+    override fun runSync(params: Params) {
+        repository.saveRestaurantId(params.restaurantId)
+    }
+}

--- a/app/src/main/java/digital/studioweb/selfhub_app/domain/features/auth/models/AssociateDeviceResponseModel.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/domain/features/auth/models/AssociateDeviceResponseModel.kt
@@ -1,0 +1,7 @@
+package digital.studioweb.selfhub_app.domain.features.auth.models
+
+data class AssociateDeviceResponseModel(
+    val statusCode: Int,
+    val message: String,
+    val restaurant: RestaurantModel,
+)

--- a/app/src/main/java/digital/studioweb/selfhub_app/domain/features/auth/models/RestaurantModel.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/domain/features/auth/models/RestaurantModel.kt
@@ -1,0 +1,8 @@
+package digital.studioweb.selfhub_app.domain.features.auth.models
+
+data class RestaurantModel(
+    val id: String,
+    val name: String,
+    val cnpj: String,
+    val createdAt: String,
+)

--- a/app/src/main/java/digital/studioweb/selfhub_app/presentation/features/activation/ActivationViewModel.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/presentation/features/activation/ActivationViewModel.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import digital.studioweb.selfhub_app.domain.features.auth.AssociateDeviceUseCase
 import digital.studioweb.selfhub_app.domain.features.auth.GetRestaurantByCNPJUseCase
 import digital.studioweb.selfhub_app.domain.features.auth.SaveCNPJUseCase
+import digital.studioweb.selfhub_app.domain.features.auth.SaveRestaurantIdUseCase
 import digital.studioweb.selfhub_app.presentation.features.activation.models.ActivationEvents
 import digital.studioweb.selfhub_app.presentation.features.activation.models.ActivationUIState
 import kotlinx.coroutines.Dispatchers
@@ -22,7 +23,8 @@ import javax.inject.Inject
 class ActivationViewModel @Inject constructor(
     private val getRestaurantByCNPJUseCase: GetRestaurantByCNPJUseCase,
     private val associateDeviceUseCase: AssociateDeviceUseCase,
-    private val saveCNPJUseCase: SaveCNPJUseCase
+    private val saveCNPJUseCase: SaveCNPJUseCase,
+    private val saveRestaurantIdUseCase: SaveRestaurantIdUseCase
 ) : ViewModel() {
 
     var uiState by mutableStateOf(ActivationUIState())
@@ -86,11 +88,15 @@ class ActivationViewModel @Inject constructor(
         )
         viewModelScope.launch(Dispatchers.IO) {
             associateDeviceUseCase.runAsync(params)
-                .onSuccess {
-                    val params = SaveCNPJUseCase.Params(
+                .onSuccess { response ->
+                    val cnpjParams = SaveCNPJUseCase.Params(
                         cnpj = uiState.cnpj
                     )
-                    saveCNPJUseCase.runSync(params)
+                    saveCNPJUseCase.runSync(cnpjParams)
+                    val restaurantParams = SaveRestaurantIdUseCase.Params(
+                        restaurantId = response.restaurant.id
+                    )
+                    saveRestaurantIdUseCase.runSync(restaurantParams)
                     goToHome()
                 }
                 .onFailure {}


### PR DESCRIPTION
## Summary
- capture restaurant details when associating device
- store restaurant id locally alongside CNPJ
- read restaurant id for home requests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689be64ef6e8832283435426cadb27c0