### PR TITLE
feat: show activation error snackbar

### DIFF
--- a/app/src/main/java/digital/studioweb/selfhub_app/presentation/features/activation/ActivationScreen.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/presentation/features/activation/ActivationScreen.kt
@@ -4,32 +4,44 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
 import digital.studioweb.selfhub_app.R
 import digital.studioweb.selfhub_app.presentation.features.activation.components.ActivationEditText
 import digital.studioweb.selfhub_app.presentation.features.activation.models.ActivationEvents
 import digital.studioweb.selfhub_app.presentation.features.activation.models.ActivationUIState
 import digital.studioweb.selfhub_app.presentation.navigation.AppScreens
+import kotlinx.coroutines.launch
 
 @Composable
 fun ActivationScreen(
@@ -62,7 +74,16 @@ private fun ActivationScreenContent(
     onEvent: (ActivationEvents) -> Unit,
     uiState: ActivationUIState
 ) {
+    val snackBarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
 
+    LaunchedEffect(uiState.errorSnackBarMessage) {
+        if (uiState.errorSnackBarMessage.isNotBlank()) {
+            coroutineScope.launch {
+                snackBarHostState.showSnackbar(uiState.errorSnackBarMessage)
+            }
+        }
+    }
 
     Box(
         modifier = Modifier
@@ -118,5 +139,34 @@ private fun ActivationScreenContent(
                 }
             }
         }
+
+        SnackbarHost(
+            hostState = snackBarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(16.dp),
+            snackbar = { data ->
+                Row(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(color = colorResource(id = R.color.error_wine))
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Error,
+                        contentDescription = "Erro",
+                        tint = colorResource(R.color.white),
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = data.visuals.message,
+                        color = colorResource(R.color.white),
+                        fontSize = 14.sp
+                    )
+                }
+            }
+        )
     }
 }

--- a/app/src/main/java/digital/studioweb/selfhub_app/presentation/features/activation/ActivationViewModel.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/presentation/features/activation/ActivationViewModel.kt
@@ -67,14 +67,16 @@ class ActivationViewModel @Inject constructor(
                     associateDevice()
                 }
                 .onFailure { exception ->
-                    if (exception.message!!.contains("404")) {
-                        uiState.copy(
-                            errorSnackBarMessage = "Ops! Parece que não temos um restaurante cadastrado com esse CNPJ em nossa base. Entre em contato pelo fone (51) 3365-9407",
-                        )
+                    val errorMessage = if (exception.message?.contains("404") == true) {
+                        "Ops! Parece que não temos um restaurante cadastrado com esse CNPJ em nossa base. Entre em contato pelo fone (51) 3365-9407"
+                    } else {
+                        "Ocorreu um erro ao ativar. Tente novamente."
                     }
+
                     uiState = uiState.copy(
                         isLoading = false,
-                        isCNPJValid = false
+                        isCNPJValid = false,
+                        errorSnackBarMessage = errorMessage
                     )
                 }
         }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -24,9 +24,9 @@
     <color name="white_alabaster">#FCFCFC</color>
 
     <!--    Edit Text-->
-    <color name="edit_text_background">#2D303E</color>"
-    <color name="edit_text_border">#393C49</color>"
-    <color name="edit_text_text">#ABBBC2</color>"
+    <color name="edit_text_background">#2D303E</color>
+    <color name="edit_text_border">#393C49</color>
+    <color name="edit_text_text">#ABBBC2</color>
 
     <!--    Colors for Text components-->
     <color name="purple_700">#FF3700B3</color>
@@ -37,6 +37,9 @@
 
     <!--    Success -->
     <color name="success_green">#2E7D32</color>
+
+    <!--    Error -->
+    <color name="error_wine">#8B1A1A</color>
 
     <!--    Rounded Button-->
     <color name="rounded_button_backgroud">#F2EFDB</color>


### PR DESCRIPTION
## Summary
- display error snackbar during activation failures with wine-red background
- propagate activation errors through view model state
- define reusable wine-red error color

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689be909e89c8322819800259db58175