### PR TITLE
chore: update backend base URL to Render service

### DIFF
--- a/app/src/main/java/digital/studioweb/selfhub_app/data/di/AppModule.kt
+++ b/app/src/main/java/digital/studioweb/selfhub_app/data/di/AppModule.kt
@@ -44,7 +44,7 @@ object AppModule {
     //region Retrofit
 
     @Provides
-    fun provideBaseUrl() = "https://selfhub-backend-dcf8eec84eed.herokuapp.com/"
+    fun provideBaseUrl() = "https://selfhub-backend.onrender.com/"
 
     @Provides
     @Singleton


### PR DESCRIPTION
### Motivation
- The backend hosting moved to `https://selfhub-backend.onrender.com` so the app's Retrofit base URL must be updated to point to the new Render service.

### Description
- Replaced the previous Heroku endpoint with `https://selfhub-backend.onrender.com/` in `app/src/main/java/digital/studioweb/selfhub_app/data/di/AppModule.kt` (kept trailing slash for Retrofit compatibility).

### Testing
- Verified the change and committed it using `rg -n "provideBaseUrl|onrender|herokuapp" app/src/main/java` to confirm the new URL, inspected the file with `nl -ba app/src/main/java/digital/studioweb/selfhub_app/data/di/AppModule.kt | sed -n '42,52p'`, and successfully created the commit with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0306919083228cb3d63c54d6a735)